### PR TITLE
Add :optional to required_or_optional and :object to validator.

### DIFF
--- a/test/paraiso_test.exs
+++ b/test/paraiso_test.exs
@@ -21,7 +21,9 @@ defmodule ParaisoTest do
             prop(:is_primary, :required, :boolean),
             prop(:notification, {:optional, false}, :boolean)
           ]}}
-      )
+      ),
+      prop(:options, :optional, :object),
+      prop(:options2, :optional, :object)
     ]
 
     ## Success case
@@ -38,7 +40,11 @@ defmodule ParaisoTest do
           "email_address" => "keshihoriuchi2@gmail.com",
           "is_primary" => false
         }
-      ]
+      ],
+      "options" => %{
+        "foo" => "bar",
+        "fizz" => "buzz"
+      }
     }
 
     {:ok, result} = Paraiso.process(sample, props)
@@ -57,7 +63,11 @@ defmodule ParaisoTest do
           is_primary: false,
           notification: false
         }
-      ]
+      ],
+      options: %{
+        "foo" => "bar",
+        "fizz" => "buzz"
+      }
     }
 
     assert(result === expect)

--- a/test/paraiso_test.exs
+++ b/test/paraiso_test.exs
@@ -21,9 +21,7 @@ defmodule ParaisoTest do
             prop(:is_primary, :required, :boolean),
             prop(:notification, {:optional, false}, :boolean)
           ]}}
-      ),
-      prop(:options, :optional, :object),
-      prop(:options2, :optional, :object)
+      )
     ]
 
     ## Success case
@@ -40,11 +38,7 @@ defmodule ParaisoTest do
           "email_address" => "keshihoriuchi2@gmail.com",
           "is_primary" => false
         }
-      ],
-      "options" => %{
-        "foo" => "bar",
-        "fizz" => "buzz"
-      }
+      ]
     }
 
     {:ok, result} = Paraiso.process(sample, props)
@@ -63,11 +57,7 @@ defmodule ParaisoTest do
           is_primary: false,
           notification: false
         }
-      ],
-      options: %{
-        "foo" => "bar",
-        "fizz" => "buzz"
-      }
+      ]
     }
 
     assert(result === expect)


### PR DESCRIPTION
Add `:optional` to required_or_optional.
- If the field is empty, do not complete the default value.
```elixir
iex> Paraiso.process(%{"a" => 1}, [Paraiso.prop(:a, :optional, :int)])
{:ok, %{a: 1}}
iex> Paraiso.process(%{"b" => 1}, [Paraiso.prop(:a, :optional, :int)])
{:ok, %{}}
```

Add `:object` to validator.
- If the value is map(), return the value as is.
```elixir
iex> Paraiso.process(
...>   %{"a" => %{"b" => "c"}},
...>   [Paraiso.prop(:a, :required, :object)]
...> )
{:ok, %{a: %{"b" => "c"}}}
iex> Paraiso.process(
...>   %{"a" => 1},
...>   [Paraiso.prop(:a, :required, :object)]
...> )
{:error, :a, :invalid}
```