### PR TITLE
Update :custom validator

### DIFF
--- a/lib/paraiso.ex
+++ b/lib/paraiso.ex
@@ -240,7 +240,7 @@ defmodule Paraiso do
 
   ### `{:custom, (value :: term() -> :ok | {:error, reason :: atom()})}`
 
-  関数で検証する。
+  関数で検証する。関数の仕様は以下
   - 成功なら `:ok` を返す
   - 成功で、バリデーション済みオブジェクトを返したければ `{:ok, <オブジェクト> :: any()}` を返す
   - 失敗なら `{:error, <失敗理由> :: atom()}` を返す

--- a/lib/paraiso.ex
+++ b/lib/paraiso.ex
@@ -240,7 +240,11 @@ defmodule Paraiso do
 
   ### `{:custom, (value :: term() -> :ok | {:error, reason :: atom()})}`
 
-  関数で検証する。関数は成功なら`:ok`、失敗なら `{:error, <失敗理由> :: atom()}` を返す
+  関数で検証する。
+  - 成功なら `:ok` を返す
+  - 成功で、バリデーション済みオブジェクトを返したければ `{:ok, <オブジェクト> :: any()}` を返す
+  - 失敗なら `{:error, <失敗理由> :: atom()}` を返す
+  - 失敗で、失敗したパスを返したければ `{:error, <失敗したパス情報> :: atom() | [atom() | integer()], <失敗理由> :: atom()}` を返す
 
       iex> Paraiso.process(
       ...>   %{"a" => 1},


### PR DESCRIPTION
- Change custom validator to return validated object and error path.

```elixir
iex> Paraiso.process(
...>   %{"a" => %{"b" => 1}},
...>   [
...>     Paraiso.prop(
...>       :a,
...>       :required,
...>       {:custom, fn %{"b" => v} -> if(v == 1, do: {:ok, %{b: v}}, else: {:error, :b, :invalid}) end}
...>     )
...>   ]
...> )
{:ok, %{a: %{b: 1}}}

iex> Paraiso.process(
...>   %{"a" => %{"b" => 2}},
...>   [
...>     Paraiso.prop(
...>       :a,
...>       :required,
...>       {:custom, fn %{"b" => v} -> if(v == 1, do: {:ok, %{b: v}}, else: {:error, :b, :invalid}) end}
...>     )
...>   ]
...> )
{:error, [:a, :b], :invalid}

iex> Paraiso.process(
...>   %{"a" => %{"b" => %{"c" => 2}}},
...>   [
...>     Paraiso.prop(
...>       :a,
...>       :required,
...>       {:custom, fn %{"b" => %{"c" => v}} -> if(v == 1, do: {:ok, %{b: %{c: v}}}, else: {:error, [:b, :c], :invalid}) end}
...>     )
...>   ]
...> )
{:error, [:a, :b, :c], :invalid}
```